### PR TITLE
Allow user to partially update sentinel configuration file

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -137,9 +137,9 @@ redis_sentinel_logfile: '""'
 redis_sentinel_syslog_ident: sentinel_{{ redis_sentinel_port }}
 redis_sentinel_oom_score_adjust: 0
 redis_sentinel_monitors: []
-# Set this to false if you monitor master via command instead hardcoded
-# in the config file
-redis_sentinel_static_monitor_master: true
+# Set this to true if you update the configuration via runtime
+# e.g: registering master to monitor via command-line instead manually edit the config file
+redis_sentinel_runtime_monitor_master: false
 # Example:
 # redis_sentinel_monitors:
 #   - name: master01

--- a/tasks/sentinel.yml
+++ b/tasks/sentinel.yml
@@ -139,7 +139,7 @@
     insertbefore: "### STATIC CONFIG STOP HERE ###"
     owner: "{{ redis_user }}"
     mode: 0640
-    when: redis_sentinel_runtime_monitor_master == true
+    backup: yes
     block: |
       # redis-sentinel {{ redis_version }} configuration file
       # sentinel_{{ redis_sentinel_port }}.conf
@@ -174,6 +174,7 @@
       syslog-enabled {{ redis_syslog_enabled }}
       syslog-ident {{ redis_sentinel_syslog_ident }}
       syslog-facility {{ redis_syslog_facility }}
+  when: redis_sentinel_runtime_monitor_master == true
 
 - name: add sentinel init config file
   template:

--- a/tasks/sentinel.yml
+++ b/tasks/sentinel.yml
@@ -120,7 +120,6 @@
     dest: /etc/redis/sentinel_{{ redis_sentinel_port }}.conf.{{ ansible_date_time['date'] }}
     owner: "{{ redis_user }}"
     mode: 0640
-    backup: yes
     remote_src: true
   
 - name: create sentinel config file

--- a/tasks/sentinel.yml
+++ b/tasks/sentinel.yml
@@ -102,6 +102,26 @@
     - redis_sentinel_pidfile != '""'
     - not sentinel_piddir.stat.exists
 
+- name: check if sentinel is running
+  command:
+    cmd: systemctl status sentinel_{{ redis_sentinel_port }}
+  ignore_errors: true
+  changed_when: false
+  register: sentinel_service_status
+  
+- name: run flushconfig to rewrite config file from current configuration
+  command:
+    cmd: "redis-cli -p {{ redis_sentinel_port }} SENTINEL FLUSHCONFIG"
+  when: sentinel_service_status | success
+
+- name: backup existing config file
+  copy:
+    src: /etc/redis/sentinel_{{ redis_sentinel_port }}.conf
+    dest: /etc/redis/sentinel_{{ redis_sentinel_port }}.conf.{{ ansible_date_time['date'] }}
+    owner: "{{ redis_user }}"
+    mode: 0640
+    backup: yes
+  
 - name: create sentinel config file
   template:
     src: redis_sentinel.conf.j2
@@ -109,6 +129,50 @@
     owner: "{{ redis_user }}"
     mode: 0640
   notify: "restart sentinel"
+  when: not redis_sentinel_runtime_monitor_master
+
+- name: update static configuration in config file
+  blockinfile:
+    path: /etc/redis/sentinel_{{ redis_sentinel_port }}.conf
+    insertafter: "### STATIC CONFIG START HERE ###"
+    insertbefore: "### STATIC CONFIG STOP HERE ###"
+    owner: "{{ redis_user }}"
+    mode: 0640
+    when: redis_sentinel_runtime_monitor_master == true
+    block: |
+      # redis-sentinel {{ redis_version }} configuration file
+      # sentinel_{{ redis_sentinel_port }}.conf
+
+      daemonize {{ redis_daemonize }}
+      protected-mode {{ redis_sentinel_protected_mode }}
+      dir {{ redis_sentinel_dir }}
+      pidfile {{ redis_sentinel_pidfile }}
+      port {{ redis_sentinel_port }}
+      bind {{ redis_sentinel_bind }}
+
+      # Security
+      {% if redis_sentinel_password %}
+      requirepass {{ redis_sentinel_password }}
+      {% endif %}
+
+      {% for master in redis_sentinel_monitors -%}
+      sentinel monitor {{ master.name }} {{ master.host }} {{ master.port }} {{ master.quorum|d('2') }}
+      {% for option in ('auth_pass', 'down_after_milliseconds', 'parallel_syncs', 'failover_timeout', 'notification_script', 'client_reconfig_script') -%}
+      {% if master[option] is defined and master[option] -%}
+      sentinel {{ option|replace('_', '-') }} {{ master.name }} {{ master[option] }}
+      {% endif %}
+      {% endfor -%}
+      {% if master['rename_commands'] is defined -%}
+      {% for command in master['rename_commands'] -%}
+      sentinel rename-command {{ master.name }} {{ command }}
+      {% endfor -%}
+      {% endif -%}
+      {% endfor -%}
+
+      logfile {{ redis_sentinel_logfile }}
+      syslog-enabled {{ redis_syslog_enabled }}
+      syslog-ident {{ redis_sentinel_syslog_ident }}
+      syslog-facility {{ redis_syslog_facility }}
 
 - name: add sentinel init config file
   template:

--- a/tasks/sentinel.yml
+++ b/tasks/sentinel.yml
@@ -135,7 +135,6 @@
 - name: update static configuration in config file
   blockinfile:
     path: /etc/redis/sentinel_{{ redis_sentinel_port }}.conf
-    insertafter: "### STATIC CONFIG START HERE ###"
     insertbefore: "### STATIC CONFIG STOP HERE ###"
     owner: "{{ redis_user }}"
     mode: 0640

--- a/tasks/sentinel.yml
+++ b/tasks/sentinel.yml
@@ -121,6 +121,7 @@
     owner: "{{ redis_user }}"
     mode: 0640
     backup: yes
+    remote_src: true
   
 - name: create sentinel config file
   template:

--- a/tasks/sentinel.yml
+++ b/tasks/sentinel.yml
@@ -112,7 +112,7 @@
 - name: run flushconfig to rewrite config file from current configuration
   command:
     cmd: "redis-cli -p {{ redis_sentinel_port }} SENTINEL FLUSHCONFIG"
-  when: sentinel_service_status | success
+  when: sentinel_service_status.rc == 0
 
 - name: backup existing config file
   copy:

--- a/templates/redis_sentinel.conf.j2
+++ b/templates/redis_sentinel.conf.j2
@@ -1,3 +1,4 @@
+### STATIC CONFIG START HERE ###
 # redis-sentinel {{ redis_version }} configuration file
 # sentinel_{{ redis_sentinel_port }}.conf
 
@@ -13,7 +14,6 @@ bind {{ redis_sentinel_bind }}
 requirepass {{ redis_sentinel_password }}
 {% endif %}
 
-{% if redis_sentinel_static_monitor_master %}
 {% for master in redis_sentinel_monitors -%}
 sentinel monitor {{ master.name }} {{ master.host }} {{ master.port }} {{ master.quorum|d('2') }}
 {% for option in ('auth_pass', 'down_after_milliseconds', 'parallel_syncs', 'failover_timeout', 'notification_script', 'client_reconfig_script') -%}
@@ -27,9 +27,10 @@ sentinel rename-command {{ master.name }} {{ command }}
 {% endfor -%}
 {% endif -%}
 {% endfor -%}
-{% endif %}
 
 logfile {{ redis_sentinel_logfile }}
 syslog-enabled {{ redis_syslog_enabled }}
 syslog-ident {{ redis_sentinel_syslog_ident }}
 syslog-facility {{ redis_syslog_facility }}
+
+### STATIC CONFIG STOP HERE ###


### PR DESCRIPTION
Allow user to partially update sentinel configuration file by setting `redis_sentinel_runtime_monitor_master` to `true`. This will skipping the default task to create configuration file.